### PR TITLE
Правит контрибуторов

### DIFF
--- a/js/doka/array-filter/index.md
+++ b/js/doka/array-filter/index.md
@@ -4,7 +4,7 @@ name: array-filter
 author: windrushfarer
 contributors:
   - nlopin
-contributors: skorobaeus
+  - skorobaeus
 ---
 
 ## Кратко


### PR DESCRIPTION
тег контрибуторов был заведен дважды строкой, а надо один раз массивом, YAML-файл при сборке ломался. Поправлено