### PR TITLE
Правит адрес до демки из практики

### DIFF
--- a/html/doka/ol/practice/ezhkov.md
+++ b/html/doka/ol/practice/ezhkov.md
@@ -74,7 +74,7 @@ permalink: false
 }
 ```
 
-<iframe title="Наследование цвета" src="../demos/ordered-list.html"></iframe>
+<iframe title="Наследование цвета" src="./demos/ordered-list.html"></iframe>
 
 ### Стилизуя псевдоэлемент `::marker`
 


### PR DESCRIPTION
Кажется, у нас есть проблема:

- Если ссылка на практику находится в демке, надо писать путь, как если бы она находилась в самой статье. 
- Если открыть практику отдельной страницей (хотя мы и запретили такой вариант), там демка работать не будет. 

<img width="289" alt="Снимок экрана 2021-04-26 в 11 57 33" src="https://user-images.githubusercontent.com/50330458/116056556-97f24e80-a686-11eb-86dc-a024cbad4902.png">
