### PR TITLE
Правит оунеров

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,6 @@
-@furtivite @solarrust @nlopin @pepelsbey @tachisis
-
 css @solarrust
 html @solarrust
 js @nlopin
 tools @nlopin
-people @furtivite
 docs @tachisis
 README.md @tachisis


### PR DESCRIPTION
Оунерство — это такой механизм, который помогает **точечно** настроить права на критические части кода, у которых на самом деле есть оунеры. В таком случае их призовут в ПР и без их участия этот код не смёржится.

Важное слово здесь «точечно». У нас сейчас есть три оунера:

- Алёна — html, css
- Коля — js, tools
- Оля — docs, ридми

Без их участия такие пулреквесты не надо мёржить, они обидятся.

Что я сделал:

1. Убрал первую строчку
  Она пыталась сделать всех оунерами всех файлов. Что это бы значило на практике, если бы она работала: при каждом ПР всех участников списка ставило бы ревьюерами. Это можно сделать в другом синтексисе, но кажется это плохая идея звать вообще всех.
2. Убрал явного оунера папки people
  Сейчас, если приходит простой ПР для папки people, то Гитхаб очень строго говорит «его может смёржить только Егор», хотя для этого кажется нет явных причин. Лучше бы оставить такие пулреквесты открытыми для всех, у кого есть права.