### PR TITLE
Добавляет превью для контента на Surge

### DIFF
--- a/.github/workflows/surge-preview.yml
+++ b/.github/workflows/surge-preview.yml
@@ -1,0 +1,42 @@
+name: Превью сборки на Surge
+
+on:
+  pull_request
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Загрузка platform
+        uses: actions/checkout@v2
+        with:
+          repository: Y-Doka/platform
+      - name: Загрузка контента
+        uses: actions/checkout@v2
+        with:
+          path: content
+      - name: Кэширование модулей
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Установка модулей
+        run: npm ci
+      - name: Сборка и публикация сайта
+        uses: afc163/surge-preview@v1
+        id: preview_step
+        with:
+          surge_token: ${{ secrets.SURGE_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dist: public
+          build: |
+            node make-links.js --default
+            npm run build
+      - name: Получение ссылки для превью
+        run: echo "Ссылка на превью — ${{ steps.preview_step.outputs.preview_url }}"

--- a/.github/workflows/surge-preview.yml
+++ b/.github/workflows/surge-preview.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Установка модулей
         run: npm ci
       - name: Сборка и публикация сайта
-        uses: afc163/surge-preview@v1
+        uses: Y-Doka/surge-preview@master
         id: preview_step
         with:
           surge_token: ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/surge-preview.yml
+++ b/.github/workflows/surge-preview.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Установка модулей
         run: npm ci
       - name: Сборка и публикация сайта
-        uses: Y-Doka/surge-preview@master
+        uses: Y-Doka/surge-preview@main
         id: preview_step
         with:
           surge_token: ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/surge-preview.yml
+++ b/.github/workflows/surge-preview.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           surge_token: ${{ secrets.SURGE_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          dist: public
+          dist: dist
           build: |
             node make-links.js --default
             npm run build

--- a/.github/workflows/surge-preview.yml
+++ b/.github/workflows/surge-preview.yml
@@ -1,4 +1,4 @@
-name: Превью сборки на Surge
+name: Surge
 
 on:
   pull_request


### PR DESCRIPTION
Попробовал превью для контента выстроить с помощью [Surge](https://surge.sh/).

Для этого существует уже готовый [экшн](https://github.com/marketplace/actions/surge-pr-preview). Получается, что можно не платить, и выглядит вроде бы интересно. Работает только при наличии ключа для SURGE_TOKEN в секретах репозитория, который нужно сгенерировать по [инструкции](https://surge.sh/help/integrating-with-circleci), предварительно скачав [npm пакет surge](https://surge.sh/help/getting-started-with-surge).

Что думаете?

