### PR TITLE
Разбивает проверку правописания на два экшна

### DIFF
--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -9,19 +9,16 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [14.x]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '14'
       - id: files
         uses: jitterbit/get-changed-files@v1
       - name: Проверка линтером
         run: |
-          npm install editorconfig-checker -g
+          npm install editorconfig-checker --global
           config=.editorconfig
           for changed_file in ${{ steps.files.outputs.all }}; do
             if [ $changed_file == $config ]

--- a/.github/workflows/yaspeller-all.yml
+++ b/.github/workflows/yaspeller-all.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Проверка правописания
-        run: yaspeller **/*.{md,html}
+        run: yaspeller --only-errors **/*.{md,html}

--- a/.github/workflows/yaspeller-all.yml
+++ b/.github/workflows/yaspeller-all.yml
@@ -1,0 +1,20 @@
+name: YaSpeller All
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  spell:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Проверка правописания
+        run: yaspeller **/*.{md,html}

--- a/.github/workflows/yaspeller-all.yml
+++ b/.github/workflows/yaspeller-all.yml
@@ -8,13 +8,10 @@ on:
 jobs:
   spell:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [14.x]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '14'
       - name: Проверка правописания
         run: yaspeller --only-errors **/*.{md,html}

--- a/.github/workflows/yaspeller-all.yml
+++ b/.github/workflows/yaspeller-all.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           node-version: '14'
       - name: Проверка правописания
-        run: yaspeller --only-errors **/*.{md,html}
+        run: npx yaspeller --only-errors **/*.{md,html}

--- a/.github/workflows/yaspeller-pr.yml
+++ b/.github/workflows/yaspeller-pr.yml
@@ -20,18 +20,21 @@ jobs:
         run: |
           npm install yaspeller -g
           config=.yaspeller.json
+          pattern=*.(md|html)
           file_list=""
           for changed_file in ${{ steps.files.outputs.all }}; do
             if [ $changed_file == $config ]
             then
               echo "Проверяются все файлы..."
-              yaspeller **/*.{md,html}
+              yaspeller **/$pattern
               break
             else
-              if grep -E '*.(md|html)' $changed_file
+              if grep -q "$pattern" $changed_file
               then
                 file_list="${file_list} ${changed_file}"
               fi
             fi
           done
-          yaspeller ${file_list}
+          if ! $file_list == ""; then
+            yaspeller ${file_list}
+          fi

--- a/.github/workflows/yaspeller-pr.yml
+++ b/.github/workflows/yaspeller-pr.yml
@@ -1,10 +1,7 @@
-name: YaSpeller
+name: YaSpeller PR
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
 
 jobs:
   spell:
@@ -26,11 +23,14 @@ jobs:
           for changed_file in ${{ steps.files.outputs.all }}; do
             if [ $changed_file == $config ]
             then
-              echo "Проверка для всех файлов"
+              echo "> проверяются все файлы..."
               yaspeller **/*.{md,html}
               break
             else
-              echo "Проверка для ${changed_file}"
-              yaspeller ${changed_file}
+              if grep -q grep -q *.(md|html) $changed_file
+              then
+                echo "> проверяется ${changed_file}"
+                yaspeller ${changed_file}
+              fi
             fi
           done

--- a/.github/workflows/yaspeller-pr.yml
+++ b/.github/workflows/yaspeller-pr.yml
@@ -28,7 +28,7 @@ jobs:
               yaspeller **/$pattern
               break
             else
-              if grep -q "${pattern}" $changed_file; then
+              if [ $(grep -q "${pattern}" $changed_file) ]; then
                 file_list="${file_list} ${changed_file}"
               fi
             fi

--- a/.github/workflows/yaspeller-pr.yml
+++ b/.github/workflows/yaspeller-pr.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           npm install yaspeller -g
           config=.yaspeller.json
-          pattern=*.(md|html)
+          pattern="*.(md|html)"
           file_list=""
           for changed_file in ${{ steps.files.outputs.all }}; do
             if [ $changed_file == $config ]; then

--- a/.github/workflows/yaspeller-pr.yml
+++ b/.github/workflows/yaspeller-pr.yml
@@ -20,17 +20,18 @@ jobs:
         run: |
           npm install yaspeller -g
           config=.yaspeller.json
+          file_list=""
           for changed_file in ${{ steps.files.outputs.all }}; do
             if [ $changed_file == $config ]
             then
-              echo "- проверяются все файлы..."
+              echo "Проверяются все файлы..."
               yaspeller **/*.{md,html}
               break
             else
               if grep -E '*.(md|html)' $changed_file
               then
-                echo "- проверяется ${changed_file}"
-                yaspeller ${changed_file}
+                file_list="${file_list} ${changed_file}"
               fi
             fi
           done
+          yaspeller ${file_list}

--- a/.github/workflows/yaspeller-pr.yml
+++ b/.github/workflows/yaspeller-pr.yml
@@ -33,6 +33,6 @@ jobs:
               fi
             fi
           done
-          if ! $file_list == ""; then
+          if $file_list != ""; then
             yaspeller ${file_list}
           fi

--- a/.github/workflows/yaspeller-pr.yml
+++ b/.github/workflows/yaspeller-pr.yml
@@ -27,7 +27,7 @@ jobs:
               yaspeller **/*.{md,html}
               break
             else
-              if [ grep -E '*.(md|html)' $changed_file ]
+              if grep -E '*.(md|html)' $changed_file
               then
                 echo "- проверяется ${changed_file}"
                 yaspeller ${changed_file}

--- a/.github/workflows/yaspeller-pr.yml
+++ b/.github/workflows/yaspeller-pr.yml
@@ -23,14 +23,12 @@ jobs:
           pattern=*.(md|html)
           file_list=""
           for changed_file in ${{ steps.files.outputs.all }}; do
-            if [ $changed_file == $config ]
-            then
+            if [ $changed_file == $config ]; then
               echo "Проверяются все файлы..."
               yaspeller **/$pattern
               break
             else
-              if grep -q "$pattern" $changed_file
-              then
+              if grep -q "${pattern}" $changed_file; then
                 file_list="${file_list} ${changed_file}"
               fi
             fi

--- a/.github/workflows/yaspeller-pr.yml
+++ b/.github/workflows/yaspeller-pr.yml
@@ -27,7 +27,7 @@ jobs:
               yaspeller **/*.{md,html}
               break
             else
-              if grep -q grep -q *.(md|html) $changed_file
+              if grep -E *.(md|html) $changed_file
               then
                 echo "> проверяется ${changed_file}"
                 yaspeller ${changed_file}

--- a/.github/workflows/yaspeller-pr.yml
+++ b/.github/workflows/yaspeller-pr.yml
@@ -6,14 +6,11 @@ on:
 jobs:
   spell:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [14.x]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '14'
       - id: files
         uses: jitterbit/get-changed-files@v1
       - name: Проверка правописания

--- a/.github/workflows/yaspeller-pr.yml
+++ b/.github/workflows/yaspeller-pr.yml
@@ -27,7 +27,7 @@ jobs:
               yaspeller **/*.{md,html}
               break
             else
-              if [ grep -E *.(md|html) $changed_file ]
+              if [ grep -E '*.(md|html)' $changed_file ]
               then
                 echo "- проверяется ${changed_file}"
                 yaspeller ${changed_file}

--- a/.github/workflows/yaspeller-pr.yml
+++ b/.github/workflows/yaspeller-pr.yml
@@ -25,7 +25,7 @@ jobs:
           for changed_file in ${{ steps.files.outputs.all }}; do
             if [ $changed_file == $config ]; then
               echo "Проверяются все файлы..."
-              yaspeller **/$pattern
+              yaspeller --only-errors **/$pattern
               break
             else
               if [ $(grep -q "${pattern}" $changed_file) ]; then
@@ -34,5 +34,5 @@ jobs:
             fi
           done
           if $file_list != ""; then
-            yaspeller ${file_list}
+            yaspeller --only-errors ${file_list}
           fi

--- a/.github/workflows/yaspeller-pr.yml
+++ b/.github/workflows/yaspeller-pr.yml
@@ -23,13 +23,13 @@ jobs:
           for changed_file in ${{ steps.files.outputs.all }}; do
             if [ $changed_file == $config ]
             then
-              echo "> проверяются все файлы..."
+              echo "- проверяются все файлы..."
               yaspeller **/*.{md,html}
               break
             else
               if [ grep -E *.(md|html) $changed_file ]
               then
-                echo "> проверяется ${changed_file}"
+                echo "- проверяется ${changed_file}"
                 yaspeller ${changed_file}
               fi
             fi

--- a/.github/workflows/yaspeller-pr.yml
+++ b/.github/workflows/yaspeller-pr.yml
@@ -1,7 +1,7 @@
 name: YaSpeller PR
 
 on:
-  pull_request:
+  pull_request
 
 jobs:
   spell:
@@ -15,7 +15,7 @@ jobs:
         uses: jitterbit/get-changed-files@v1
       - name: Проверка правописания
         run: |
-          npm install yaspeller -g
+          npm install yaspeller --global
           config=.yaspeller.json
           pattern="*.(md|html)"
           file_list=""
@@ -25,7 +25,7 @@ jobs:
               yaspeller --only-errors **/$pattern
               break
             else
-              if [ $(grep -q "${pattern}" $changed_file) ]; then
+              if [ $(grep --quiet "${pattern}" $changed_file) ]; then
                 file_list="${file_list} ${changed_file}"
               fi
             fi

--- a/.github/workflows/yaspeller-pr.yml
+++ b/.github/workflows/yaspeller-pr.yml
@@ -27,7 +27,7 @@ jobs:
               yaspeller **/*.{md,html}
               break
             else
-              if grep -E *.(md|html) $changed_file
+              if [ grep -E *.(md|html) $changed_file ]
               then
                 echo "> проверяется ${changed_file}"
                 yaspeller ${changed_file}


### PR DESCRIPTION
@pepelsbey @nlopin @furtivite, предлагаю разбить проверку правописания на два трэка: при пуше в ветку `main` и при PR. Что думаете?

Внёс условие для `Yaspeller`, чтобы он не проверял файлы, если они не *.md и не *.html. Попробую запихнуть такие и другие файлы, отладить, а потом удалить всё лишнее. Должно сработать. Это проблема, которая описана в #751.