### PR TITLE
Исправляет ошибки в тестах

### DIFF
--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: '14'
       - id: files
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v1.2
       - name: Проверка линтером
         run: |
           npm install editorconfig-checker --global

--- a/.github/workflows/yaspeller-pr.yml
+++ b/.github/workflows/yaspeller-pr.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: '14'
       - id: files
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v1.2
       - name: Проверка правописания
         run: |
           npm install yaspeller --global


### PR DESCRIPTION
В экшне исправлена ошибка, которая афектила:
1. https://github.com/Y-Doka/content/pull/717
2. https://github.com/Y-Doka/content/pull/733
3. https://github.com/Y-Doka/content/pull/819

Решение проблемы [найдено](https://github.com/jitterbit/get-changed-files/pull/25) и уже воплощено в [форке](https://github.com/Ana06/get-changed-files/releases/tag/v1.2) прежнего [экшна](https://github.com/jitterbit/get-changed-files). В PR заменил пока на форк. Из плюсов: теперь можем ещё и фильтровать файлы из пиара, если будет нужно.